### PR TITLE
OS Agnostic paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ import react from "@vitejs/plugin-react";
 import { keycloakify } from "keycloakify/vite-plugin";
 import themes from "./themes";
 import { buildEmailTheme } from "keycloakify-emails";
+import path from "node:path";
 
 export default defineConfig({
   plugins: [
@@ -56,7 +57,11 @@ export default defineConfig({
       accountThemeImplementation: "none",
       postBuild: async (buildContext) => {
         await buildEmailTheme({
-          templatesSrcDirPath: import.meta.dirname + "/emails/templates",
+          templatesSrcDirPath: path.join(
+            import.meta.dirname,
+            "emails",
+            "templates",
+          ),
           themeNames: buildContext.themeNames,
           keycloakifyBuildDirPath: buildContext.keycloakifyBuildDirPath,
           locales: ["en", "pl"],

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { keycloakify } from "keycloakify/vite-plugin";
 import { buildEmailTheme } from "keycloakify-emails";
+import path from "node:path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -16,8 +17,8 @@ export default defineConfig({
         const config = await loadConfig;
 
         await buildEmailTheme({
-          templatesSrcDirPath: import.meta.dirname + "/emails/templates",
-          i18nSourceFile: import.meta.dirname + "/emails/i18n.ts",
+          templatesSrcDirPath: path.join(import.meta.dirname, "emails", "templates"),
+          i18nSourceFile: path.join(import.meta.dirname, "emails", "i18n.ts"),
           themeNames: buildContext.themeNames,
           keycloakifyBuildDirPath: buildContext.keycloakifyBuildDirPath,
           locales: ["en", "pl"],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises";
 import { test, describe } from "vitest";
 import { compareFolders } from "./utils.js";
 import { buildEmailTheme } from "../src/index.js";
+import path from "node:path";
 
 async function prepare(caseFolderName: string) {
   const rootDir = nodepath.join(import.meta.dirname, caseFolderName);
@@ -24,9 +25,14 @@ describe("Smoke Test", () => {
 
     await buildEmailTheme({
       cwd: rootDir,
-      i18nSourceFile: rootDir + "/fixtures/emails/i18n.ts",
-      templatesSrcDirPath: rootDir + "/fixtures/emails/templates",
-      assetsDirPath: rootDir + "/fixtures/emails/assets",
+      i18nSourceFile: path.join(rootDir, "fixtures", "emails", "i18n.ts"),
+      templatesSrcDirPath: path.join(
+        rootDir,
+        "fixtures",
+        "emails",
+        "templates",
+      ),
+      assetsDirPath: path.join(rootDir, "fixtures", "emails", "assets"),
       locales: ["en", "pl"],
       themeNames: ["vanilla", "chocolate"],
       keycloakifyBuildDirPath: actualPath,
@@ -40,9 +46,9 @@ describe("Smoke Test", () => {
 
     await buildEmailTheme({
       cwd: rootDir,
-      i18nSourceFile: "./fixtures/emails/i18n.ts",
-      templatesSrcDirPath: "./fixtures/emails/templates",
-      assetsDirPath: "./fixtures/emails/assets",
+      i18nSourceFile: path.join(".", "fixtures", "emails", "i18n.ts"),
+      templatesSrcDirPath: path.join(".", "fixtures", "emails", "templates"),
+      assetsDirPath: path.join(".", "fixtures", "emails", "assets"),
       locales: ["en", "pl"],
       themeNames: ["vanilla", "chocolate"],
       keycloakifyBuildDirPath: actualPath,
@@ -56,7 +62,7 @@ describe("Smoke Test", () => {
 
     await buildEmailTheme({
       cwd: rootDir,
-      templatesSrcDirPath: "./fixtures/emails/templates",
+      templatesSrcDirPath: path.join(".", "fixtures", "emails", "templates"),
       locales: ["en", "pl"],
       themeNames: ["vanilla"],
       keycloakifyBuildDirPath: actualPath,


### PR DESCRIPTION
Hello @timofei-iatsenko,

Just a small nitpick: a substantial portion of the user base uses Windows.
I prefer handling paths in an OS-agnostic way to avoid confusion.

I understand that you internally call path.resolve, which ensures paths are normalized. However, I still think it feels off to recommend users pass something like this as an argument:

C:\user\john\github/email/template