### PR TITLE
Add instruction to install required peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The library includes a set of React components and utilities designed to simplif
 ## Installation
 
 ```bash
-npm install --save-dev keycloakify-emails
-# yarn add --dev keycloakify-emails
+npm install --save-dev keycloakify-emails jsx-email react
+# yarn add --dev keycloakify-emails jsx-email react
 ```
 
 ## Usage


### PR DESCRIPTION
Adding instruction for installing required peedDeps.  

React could seem obvious but Keycloakify support Angular and Svelte.