### PR TITLE
fix: handle already camel cased filenames for messages

### DIFF
--- a/src/build-theme/utils.ts
+++ b/src/build-theme/utils.ts
@@ -4,6 +4,10 @@ import * as propertiesParser from "properties-parser";
 import type { BuildEmailThemeOptions } from "./types.js";
 
 export function toCamelCase(str: string) {
+  if (/^[a-z]+([A-Z][a-z]*)*$/.test(str)) {
+    return str;
+  }
+
   return str
     .toLowerCase()
     .replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());

--- a/test/build-theme/utils.test.ts
+++ b/test/build-theme/utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+import { toCamelCase } from "../../src/build-theme/utils.js";
+
+describe("Utils tests", () => {
+  describe("toCamelCase", () => {
+    test.each([
+      ["email-test", "emailTest"],
+      ["event-update_totp", "eventUpdateTotp"],
+      [
+        "event-user_disabled_by_temporary_lockout",
+        "eventUserDisabledByTemporaryLockout",
+      ],
+      ["executeActions", "executeActions"],
+      ["sTranGe-Custom-eMAIl", "strangeCustomEmail"],
+      ["org-invite", "orgInvite"],
+      ["password-reset", "passwordReset"],
+    ])("should convert %s to %s", (source, result) => {
+      expect(toCamelCase(source)).toBe(result);
+    });
+  });
+});


### PR DESCRIPTION
Hi there. That minor fix focused on resolving issues with incorrect compiling messages from the subject if the template is already in camelCase, like in the case of customization of **execute actions.ftl**

With the following template:
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/087114a0-b4d3-4ea5-a649-0cc9231f7459" />

Causes next:
<img width="706" alt="image" src="https://github.com/user-attachments/assets/4160dea6-e7fa-42c6-b7fc-543b2c157bb8" />

With provided changes, everything will be okay
