### PR TITLE
feat: separate endpoint for createVariablesHelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,22 @@ const { exp } = createVariablesHelper("email-verification.ftl");
 
 The `exp("realmName")` argument is type-checked, ensuring that only valid template variables are available and accessible for the specified template.
 
+### Extending default type definition
+
+You can extend the default variable definitions using typescript [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html).
+
+```ts
+declare module "keycloakify-emails/variables" {
+  interface ProfileBean {
+    foo: string;
+  }
+}
+
+exp("user.foo");
+```
+
+You can find all available interfaces to extend in this repo in `src/kc-email-vars.ts` file.
+
 ### Condition
 
 Facilitates writing `if/elseif/else` expressions for Freemarker templates.

--- a/README.md
+++ b/README.md
@@ -191,12 +191,8 @@ Follow their [quick-start guide](https://jsx.email/docs/quick-start) to set up j
 Then you will be able to create templates using `jsx-email` components:
 
 ```tsx
-import {
-  GetSubject,
-  GetTemplate,
-  GetTemplateProps,
-  createVariablesHelper,
-} from "keycloakify-emails";
+import { GetSubject, GetTemplate, GetTemplateProps } from "keycloakify-emails";
+import { createVariablesHelper } from "keycloakify-emails/variables";
 import {
   Text,
   Body,
@@ -314,7 +310,7 @@ This approach ensures compatibility with both Keycloak and the JSX-Email preview
 This function provides a type-safe way to write expressions for templates.
 
 ```tsx
-import { createVariablesHelper } from "keycloakify-emails";
+import { createVariablesHelper } from "keycloakify-emails/variables";
 const { exp } = createVariablesHelper("email-verification.ftl");
 
 <Text style={paragraph}>
@@ -351,23 +347,23 @@ For simpler cases, you can use `If` without the `Then` case:
 
 ## Keycloak email templates reference
 
-| Template name                                | Description                     |
-| -------------------------------------------- | ------------------------------- |
-| email-test.ftl                               | Test email template             |
-| email-update-confirmation.ftl                | Email update confirmation       |
-| email-verification.ftl                       | Email verification              |
-| event-login_error.ftl                        | Login error event notification  |
-| event-remove_credential.ftl                  | Credential removal notification |
-| event-remove_totp.ftl                        | TOTP removal notification       |
-| event-update_credential.ftl                  | Credential update notification  |
-| event-update_password.ftl                    | Password update notification    |
-| event-update_totp.ftl                        | TOTP update notification        |
-| event-user_disabled_by_permanent_lockout.ftl | Permanent lockout notification  |
-| event-user_disabled_by_temporary_lockout.ftl | Temporary lockout notification  |
-| executeActions.ftl                           | Execute actions email           |
-| identity-provider-link.ftl                   | Identity provider link email    |
-| org-invite.ftl                               | Organization invitation         |
-| password-reset.ftl                           | Password reset email            |
+| Template name                                                                                                                                                                               | Description                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| [email-test.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/email-test.ftl)                                                             | Test email template             |
+| [email-update-confirmation.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/email-update-confirmation.ftl)                               | Email update confirmation       |
+| [email-verification.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/email-verification.ftl)                                             | Email verification              |
+| [event-login_error.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/event-login_error.ftl)                                               | Login error event notification  |
+| [event-remove_credential.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/event-remove_credential.ftl)                                   | Credential removal notification |
+| [event-remove_totp.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/event-remove_totp.ftl)                                               | TOTP removal notification       |
+| [event-update_credential.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/event-update_credential.ftl)                                   | Credential update notification  |
+| [event-update_password.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/event-update_password.ftl)                                       | Password update notification    |
+| [event-update_totp.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/event-update_totp.ftl)                                               | TOTP update notification        |
+| [event-user_disabled_by_permanent_lockout.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/event-user_disabled_by_permanent_lockout.ftl) | Permanent lockout notification  |
+| [event-user_disabled_by_temporary_lockout.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/event-user_disabled_by_temporary_lockout.ftl) | Temporary lockout notification  |
+| [executeActions.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/executeActions.ftl)                                                     | Execute actions email           |
+| [identity-provider-link.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/identity-provider-link.ftl)                                     | Identity provider link email    |
+| [org-invite.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/org-invite.ftl)                                                             | Organization invitation         |
+| [password-reset.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/email/html/password-reset.ftl)                                                     | Password reset email            |
 
 ## License
 

--- a/example/emails/templates/email-test.tsx
+++ b/example/emails/templates/email-test.tsx
@@ -1,12 +1,7 @@
 import { render, Text, Img, Container } from "jsx-email";
 import { EmailLayout } from "../layout";
-import {
-  createVariablesHelper,
-  GetSubject,
-  GetTemplate,
-  GetTemplateProps,
-} from "keycloakify-emails";
-
+import { createVariablesHelper } from "keycloakify-emails/variables";
+import { GetSubject, GetTemplate, GetTemplateProps } from "keycloakify-emails";
 interface TemplateProps extends Omit<GetTemplateProps, "plainText"> {}
 
 const paragraph = {

--- a/example/emails/templates/email-update-confirmation.tsx
+++ b/example/emails/templates/email-update-confirmation.tsx
@@ -1,11 +1,7 @@
 import { Text, render } from "jsx-email";
 import { EmailLayout } from "../layout";
-import {
-  GetSubject,
-  GetTemplate,
-  GetTemplateProps,
-  createVariablesHelper,
-} from "keycloakify-emails";
+import { GetSubject, GetTemplate, GetTemplateProps } from "keycloakify-emails";
+import { createVariablesHelper } from "keycloakify-emails/variables";
 interface TemplateProps extends Omit<GetTemplateProps, "plainText"> {}
 
 const paragraph = {

--- a/example/emails/templates/email-verification.tsx
+++ b/example/emails/templates/email-verification.tsx
@@ -1,11 +1,7 @@
 import { Text, render } from "jsx-email";
 import { EmailLayout } from "../layout";
-import {
-  createVariablesHelper,
-  GetSubject,
-  GetTemplate,
-  GetTemplateProps,
-} from "keycloakify-emails";
+import { GetSubject, GetTemplate, GetTemplateProps } from "keycloakify-emails";
+import { createVariablesHelper } from "keycloakify-emails/variables";
 
 interface TemplateProps extends Omit<GetTemplateProps, "plainText"> {}
 

--- a/example/emails/templates/org-invite.tsx
+++ b/example/emails/templates/org-invite.tsx
@@ -1,12 +1,8 @@
 import { Text, render } from "jsx-email";
 import { EmailLayout } from "../layout";
 import * as Fm from "keycloakify-emails/jsx-email";
-import {
-  createVariablesHelper,
-  GetSubject,
-  GetTemplate,
-  GetTemplateProps,
-} from "keycloakify-emails";
+import { GetSubject, GetTemplate, GetTemplateProps } from "keycloakify-emails";
+import { createVariablesHelper } from "keycloakify-emails/variables";
 
 interface TemplateProps extends Omit<GetTemplateProps, "plainText"> {}
 

--- a/example/emails/templates/password-reset.tsx
+++ b/example/emails/templates/password-reset.tsx
@@ -1,11 +1,7 @@
 import { Text, render } from "jsx-email";
 import { EmailLayout } from "../layout";
-import {
-  createVariablesHelper,
-  GetSubject,
-  GetTemplate,
-  GetTemplateProps,
-} from "keycloakify-emails";
+import { GetSubject, GetTemplate, GetTemplateProps } from "keycloakify-emails";
+import { createVariablesHelper } from "keycloakify-emails/variables";
 
 interface TemplateProps extends Omit<GetTemplateProps, "plainText"> {}
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.mjs"
     },
+    "./variables": {
+      "types": "./dist/variables.d.ts",
+      "default": "./dist/variables.mjs"
+    },
     "./jsx-email": {
       "types": "./dist/jsx-email/index.d.ts",
       "default": "./dist/jsx-email/index.mjs"

--- a/src/build-theme/utils.test.ts
+++ b/src/build-theme/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { toCamelCase } from "../../src/build-theme/utils.js";
+import { toCamelCase } from "./utils.js";
 
 describe("Utils tests", () => {
   describe("toCamelCase", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
 export * from "./build-theme/build-email-theme.js";
 export type { BuildEmailThemeOptions } from "./build-theme/types.js";
 export type * from "./types.js";
-export type * from "./kc-email-vars.js";
-export { createVariablesHelper } from "./create-variables-helper.js";

--- a/src/kc-email-vars.ts
+++ b/src/kc-email-vars.ts
@@ -15,31 +15,31 @@ type Path<T, K extends keyof T = keyof T> = K extends string // Ensure keys are 
 /**
  * org.keycloak.models.OrganizationModel
  */
-export type OrganizationModel = {
+export interface OrganizationModel {
   name: string;
   alias: string;
   enabled: boolean;
   description: string;
   redirectUrl: string;
   attributes: Record<string, string[]>;
-};
+}
 
-export type BrokeredIdentityContext = {
+export interface BrokeredIdentityContext {
   username: string;
-};
+}
 
-export type ProfileBean = {
+export interface ProfileBean {
   username: string;
   firstName: string;
   lastName: string;
   email: string;
   attributes: () => Record<string, string>;
-};
+}
 
 /**
  * org.keycloak.forms.login.freemarker.model.UrlBean;
  */
-export type UrlBean = {
+export interface UrlBean {
   loginAction: string;
   loginUrl: string;
   loginRestartFlowUrl: string;
@@ -56,15 +56,15 @@ export type UrlBean = {
   oauth2DeviceVerificationAction: string;
   resourcesPath: string;
   resourcesCommonPath: string;
-};
+}
 
-export type EventBean = {
+export interface EventBean {
   date: string;
   ipAddress: string;
   details: UnknownObject;
-};
+}
 
-export type BaseVars = {
+export interface BaseVars {
   locale: string;
   /**
    * org.keycloak.theme.Theme.getProperties()
@@ -73,7 +73,7 @@ export type BaseVars = {
   realmName: string;
   user: ProfileBean;
   url: UrlBean;
-};
+}
 
 export type LinkVars = {
   link: string;

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,0 +1,2 @@
+export type * from "./kc-email-vars.js";
+export { createVariablesHelper } from "./create-variables-helper.js";


### PR DESCRIPTION
The types describing variables available in templates now defined as interfaces. This allows to use "declaration merging" approach to extend them in consumers code.

Documentation is updated with an example how to extend a type. 

BREAKING CHANGE:

`createVariablesHelper` and all Model types are now exported from `keycloakify-emails/variables`, please update your imports.