### PR TITLE
feat: discover templates also on templatesSrcDirPath subfolders

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -94,4 +94,19 @@ describe("Smoke Test", () => {
       }),
     ).rejects.toThrowError();
   });
+
+  test("Should work with subfolders", async () => {
+    const { rootDir, actualPath, expectedPath } =
+      await prepare("with-subfolders");
+
+    await buildEmailTheme({
+      cwd: rootDir,
+      templatesSrcDirPath: "./fixtures/emails/templates",
+      locales: ["en"],
+      themeNames: ["vanilla"],
+      keycloakifyBuildDirPath: actualPath,
+    });
+
+    compareFolders(actualPath, expectedPath);
+  });
 });

--- a/test/with-subfolders/expected/resources/theme/vanilla/email/html/email-test.ftl
+++ b/test/with-subfolders/expected/resources/theme/vanilla/email/html/email-test.ftl
@@ -1,0 +1,1 @@
+<#include "./" + locale + "/email-test.ftl">

--- a/test/with-subfolders/expected/resources/theme/vanilla/email/html/email-verification.ftl
+++ b/test/with-subfolders/expected/resources/theme/vanilla/email/html/email-verification.ftl
@@ -1,0 +1,1 @@
+<#include "./" + locale + "/email-verification.ftl">

--- a/test/with-subfolders/expected/resources/theme/vanilla/email/html/en/email-test.ftl
+++ b/test/with-subfolders/expected/resources/theme/vanilla/email/html/en/email-test.ftl
@@ -1,0 +1,1 @@
+email-test.ftl > template {"themeName":"vanilla","locale":"en","plainText":false}

--- a/test/with-subfolders/expected/resources/theme/vanilla/email/html/en/email-verification.ftl
+++ b/test/with-subfolders/expected/resources/theme/vanilla/email/html/en/email-verification.ftl
@@ -1,0 +1,1 @@
+email-verification.ftl > template {"themeName":"vanilla","locale":"en","plainText":false}

--- a/test/with-subfolders/expected/resources/theme/vanilla/email/messages/messages_en.properties
+++ b/test/with-subfolders/expected/resources/theme/vanilla/email/messages/messages_en.properties
@@ -1,0 +1,2 @@
+emailTestSubject=email-test.ftl > Subject{"locale":"en","themeName":"vanilla"}
+emailVerificationSubject=email-verification.ftl > Subject{"locale":"en","themeName":"vanilla"}

--- a/test/with-subfolders/expected/resources/theme/vanilla/email/text/email-test.ftl
+++ b/test/with-subfolders/expected/resources/theme/vanilla/email/text/email-test.ftl
@@ -1,0 +1,1 @@
+<#include "./" + locale + "/email-test.ftl">

--- a/test/with-subfolders/expected/resources/theme/vanilla/email/text/email-verification.ftl
+++ b/test/with-subfolders/expected/resources/theme/vanilla/email/text/email-verification.ftl
@@ -1,0 +1,1 @@
+<#include "./" + locale + "/email-verification.ftl">

--- a/test/with-subfolders/expected/resources/theme/vanilla/email/text/en/email-test.ftl
+++ b/test/with-subfolders/expected/resources/theme/vanilla/email/text/en/email-test.ftl
@@ -1,0 +1,1 @@
+email-test.ftl > template {"themeName":"vanilla","locale":"en","plainText":true}

--- a/test/with-subfolders/expected/resources/theme/vanilla/email/text/en/email-verification.ftl
+++ b/test/with-subfolders/expected/resources/theme/vanilla/email/text/en/email-verification.ftl
@@ -1,0 +1,1 @@
+email-verification.ftl > template {"themeName":"vanilla","locale":"en","plainText":true}

--- a/test/with-subfolders/expected/resources/theme/vanilla/email/theme.properties
+++ b/test/with-subfolders/expected/resources/theme/vanilla/email/theme.properties
@@ -1,0 +1,2 @@
+parent=base
+locales=en

--- a/test/with-subfolders/fixtures/emails/templates/test/email-test.tsx
+++ b/test/with-subfolders/fixtures/emails/templates/test/email-test.tsx
@@ -1,0 +1,13 @@
+import {
+  GetSubject,
+  GetTemplate,
+  GetTemplateProps,
+} from "../../../../../../src/index.js";
+
+export const getTemplate: GetTemplate = async (props) => {
+  return "email-test.ftl > template " + JSON.stringify(props);
+};
+
+export const getSubject: GetSubject = async (props) => {
+  return "email-test.ftl > Subject" + JSON.stringify(props);
+};

--- a/test/with-subfolders/fixtures/emails/templates/verification/email-verification.tsx
+++ b/test/with-subfolders/fixtures/emails/templates/verification/email-verification.tsx
@@ -1,0 +1,13 @@
+import {
+  GetSubject,
+  GetTemplate,
+  GetTemplateProps,
+} from "../../../../../../src/index.js";
+
+export const getTemplate: GetTemplate = async (props) => {
+  return "email-verification.ftl > template " + JSON.stringify(props);
+};
+
+export const getSubject: GetSubject = async (props) => {
+  return "email-verification.ftl > Subject" + JSON.stringify(props);
+};


### PR DESCRIPTION
Allow to create subfolders on templatesSrcDirPath

added "Should work with subfolders" test