### PR TITLE
change on render-messages

### DIFF
--- a/src/build-theme/render-messages.ts
+++ b/src/build-theme/render-messages.ts
@@ -30,11 +30,14 @@ export async function renderMessages(
     : {};
 
   for (const mod of templates) {
-    messages[toCamelCase(getBaseName(mod.file)) + "Subject"] =
-      await mod.getSubject({
-        locale,
-        themeName,
-      });
+    const subject = await mod.getSubject({
+      locale,
+      themeName,
+    });
+
+    const defaultMessage = toCamelCase(getBaseName(mod.file)) + "Subject";
+
+    messages[subject.messageVariableName || defaultMessage] = subject.title;
   }
 
   await writePropertiesFile(

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,12 @@ export type GetTemplate<T extends string = string> = (
 export type GetSubject<T extends string = string> = (props: {
   locale: string;
   themeName: T;
-}) => Promise<string>;
+}) => Promise<{
+  // The message variable name is used to reference the subject in the messages file.
+  messageVariableName?: string;
+  // The title is the actual subject line of the email.
+  title: string;
+}>;
 export type GetMessages<T extends string = string> = (props: {
   locale: string;
   themeName: T;


### PR DESCRIPTION
## Summary of Changes
This update modifies how email subjects are stored in the `messages` object when rendering templates.  
Instead of always using a default key derived from the file name, each subject can now optionally specify a custom message variable name.

---

## Details

### 1. Refactored `getSubject` return type
- The `GetSubject` type now returns an object containing:
  - **`messageVariableName`** (`string`): Optional custom key for storing the subject in the messages file.
  - **`title`** (`string`): The actual subject text.
- This replaces the previous behavior where `getSubject` returned only a string.

### 2. Updated `renderMessages` implementation
- **Before**:
  - The subject text was stored directly in the `messages` object under a key based on the file name with `"Subject"` appended.
- **Now**:
  - `getSubject` returns an object (`subject`) with `messageVariableName` and `title`.
  - A default key is still generated from the file name (`defaultMessage`).
  - If `messageVariableName` is provided, it is used as the key; otherwise, the default key is used.
  - The value stored in `messages` is the `title` from the subject.

### 3. Benefit
- Adds flexibility: templates can define their own message variable names for subjects.
- Improves maintainability and clarity when mapping subjects, especially when file names differ from variable names.