### PR TITLE
feat: Add TypeScript support for FreeMarker expressions

### DIFF
--- a/src/create-variables-helper.test-d.ts
+++ b/src/create-variables-helper.test-d.ts
@@ -1,0 +1,108 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { createVariablesHelper } from "./create-variables-helper.js";
+
+describe("createVariablesHelper type tests", () => {
+  describe("org-invite.ftl", () => {
+    const { exp, v } = createVariablesHelper("org-invite.ftl");
+
+    test("accepts valid property paths", () => {
+      expectTypeOf(exp("organization.name")).toBeString();
+      expectTypeOf(exp("firstName")).toBeString();
+      expectTypeOf(exp("lastName")).toBeString();
+      expectTypeOf(exp("link")).toBeString();
+      expectTypeOf(exp("linkExpiration")).toBeString();
+      expectTypeOf(exp("linkExpirationFormatter(linkExpiration)")).toBeString();
+    });
+
+    test("accepts FreeMarker array access syntax", () => {
+      expectTypeOf(exp("organization.attributes[0]")).toBeString();
+    });
+
+    test("accepts FreeMarker null-safe operator", () => {
+      expectTypeOf(exp("firstName??")).toBeString();
+      expectTypeOf(exp("organization.name??")).toBeString();
+      expectTypeOf(exp("organization.attributes[0]??")).toBeString();
+    });
+
+    test("accepts FreeMarker fallback syntax", () => {
+      expectTypeOf(exp("firstName!lastName")).toBeString();
+      expectTypeOf(exp("organization.name!realmName")).toBeString();
+      expectTypeOf(
+        exp("organization.attributes[0]!organization.name"),
+      ).toBeString();
+    });
+
+    test("accepts FreeMarker grouped fallback syntax", () => {
+      expectTypeOf(exp("(firstName)!lastName")).toBeString();
+      expectTypeOf(
+        exp("(organization.attributes[0])!organization.name"),
+      ).toBeString();
+    });
+
+    test("v() accepts the same patterns as exp()", () => {
+      expectTypeOf(v("organization.name")).toBeString();
+      expectTypeOf(v("firstName!lastName")).toBeString();
+      expectTypeOf(v("(firstName)!lastName")).toBeString();
+    });
+
+    test("rejects invalid paths", () => {
+      // @ts-expect-error - "invalid" is not a valid path
+      exp("invalid");
+
+      // @ts-expect-error - "typo.name" is not a valid path
+      exp("typo.name");
+
+      // @ts-expect-error - invalid path in array access
+      exp("invalid[0]");
+
+      // @ts-expect-error - invalid path in null-safe
+      exp("invalid??");
+
+      // @ts-expect-error - invalid path in fallback (first part)
+      exp("invalid!firstName");
+
+      // @ts-expect-error - invalid path in fallback (second part)
+      exp("firstName!invalid");
+
+      // @ts-expect-error - invalid path in grouped fallback
+      exp("(invalid)!firstName");
+    });
+  });
+
+  describe("email-verification.ftl", () => {
+    const { exp } = createVariablesHelper("email-verification.ftl");
+
+    test("accepts valid property paths", () => {
+      expectTypeOf(exp("user.firstName")).toBeString();
+      expectTypeOf(exp("user.lastName")).toBeString();
+      expectTypeOf(exp("link")).toBeString();
+      expectTypeOf(exp("realmName")).toBeString();
+    });
+
+    test("accepts FreeMarker expressions with valid paths", () => {
+      expectTypeOf(exp("user.firstName!user.lastName")).toBeString();
+      expectTypeOf(exp("user.firstName??")).toBeString();
+    });
+
+    test("rejects paths from other templates", () => {
+      // @ts-expect-error - "organization" doesn't exist in email-verification
+      exp("organization.name");
+    });
+  });
+
+  describe("event-login_error.ftl", () => {
+    const { exp } = createVariablesHelper("event-login_error.ftl");
+
+    test("accepts valid event property paths", () => {
+      expectTypeOf(exp("event.date")).toBeString();
+      expectTypeOf(exp("event.ipAddress")).toBeString();
+    });
+
+    test("accepts event.details with any property (UnknownObject)", () => {
+      expectTypeOf(exp("event.details.credential_type")).toBeString();
+      expectTypeOf(
+        exp("event.details.credential_type!event.details.fallback"),
+      ).toBeString();
+    });
+  });
+});

--- a/src/create-variables-helper.ts
+++ b/src/create-variables-helper.ts
@@ -1,10 +1,17 @@
-import { KcEmailVars } from "./kc-email-vars.js";
+import { FreemarkerExpression, KcEmailVars } from "./kc-email-vars.js";
 
 export function createVariablesHelper<EmailId extends KcEmailVars["emailId"]>(
   _emailId: EmailId,
 ) {
   type MatchingEmail = Extract<KcEmailVars, { emailId: EmailId }>;
   type ValidPaths = MatchingEmail["vars"];
+
+  /**
+   * Expression type that accepts either:
+   * - Valid property paths for the email template (type-safe)
+   * - FreeMarker expressions with validated paths (array access, fallbacks, null-safe)
+   */
+  type Expression = ValidPaths | FreemarkerExpression<ValidPaths>;
 
   return {
     /**
@@ -16,11 +23,19 @@ export function createVariablesHelper<EmailId extends KcEmailVars["emailId"]>(
      *     this was you, click the link below to verify your email address
      *   </p>
      * ```
+     *
+     * Also supports FreeMarker syntax like fallbacks and array access:
+     * ```jsx
+     *   <p>
+     *     Organization: {exp("(organization.attributes.displayName[0])!organization.name")}
+     *   </p>
+     * ```
      */
-    exp: (name: ValidPaths) => "${" + name + "}",
+    exp: (name: Expression) => "${" + name + "}",
     /**
-     * Print just a variable name, useful in a complex expressions
+     * Print just a variable name, useful in a complex expressions.
+     * Also supports FreeMarker syntax patterns.
      */
-    v: (name: ValidPaths) => name,
+    v: (name: Expression) => name,
   };
 }

--- a/src/kc-email-vars.ts
+++ b/src/kc-email-vars.ts
@@ -10,6 +10,54 @@ type Path<T, K extends keyof T = keyof T> = K extends string // Ensure keys are 
         : `${K}` // For primitives or other types, just return the key
   : never;
 
+/**
+ * FreeMarker expression pattern helpers.
+ * These are generic types that validate paths against ValidPaths.
+ *
+ * @example
+ * ```ts
+ * // All of these are valid FreeMarker expressions:
+ * exp('organization.attributes.displayName[0]')
+ * exp('(organization.attributes.displayName[0])!organization.name')
+ * exp('user.firstName??')
+ * ```
+ */
+
+/** Array indexing pattern: path[0], path[1], etc. */
+export type FmArrayAccess<ValidPath extends string> = `${ValidPath}[${number}]`;
+
+/** Null-safe operator pattern: path?? */
+export type FmNullSafe<ValidPath extends string> = `${ValidPath}??`;
+
+/** Simple fallback pattern: path!fallback */
+export type FmFallback<
+  ValidPath extends string,
+  FallbackPath extends string = ValidPath,
+> = `${ValidPath}!${FallbackPath}`;
+
+/** Grouped fallback pattern: (expr)!fallback */
+export type FmGroupedFallback<
+  ValidPath extends string,
+  FallbackPath extends string = ValidPath,
+> = `(${ValidPath})!${FallbackPath}`;
+
+/**
+ * Combined type for FreeMarker expressions with validated paths.
+ * Use this with ValidPaths to get type-safe FreeMarker expressions.
+ */
+export type FreemarkerExpression<ValidPath extends string> =
+  // Array access
+  | FmArrayAccess<ValidPath>
+  // Null-safe operator
+  | FmNullSafe<ValidPath>
+  | FmNullSafe<FmArrayAccess<ValidPath>>
+  // Simple fallback
+  | FmFallback<ValidPath>
+  | FmFallback<FmArrayAccess<ValidPath>, ValidPath>
+  // Grouped fallback (path or array access inside parens)
+  | FmGroupedFallback<ValidPath>
+  | FmGroupedFallback<FmArrayAccess<ValidPath>, ValidPath>;
+
 // refer to https://github.dev/keycloak/keycloak/tree/main/services/src/main/java/org/keycloak/email/freemarker
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    typecheck: {
+      enabled: true,
+      include: ["**/*.test-d.ts"],
+      ignoreSourceErrors: true,
+    },
+  },
+});


### PR DESCRIPTION
The exp function now accepts FreeMarker expressions in addition to valid property paths. This allows users to use FreeMarker syntax like:
- Array indexing: `organization.attributes.displayName[0]`
- Fallback operator: `expression!fallbackValue`
- Grouped fallback: `(expression)!fallbackValue`
- Null-safe operator: `expression??`

Previously, users had to add @ts-expect-error comments to use these patterns. Now they can use them directly with full type support.